### PR TITLE
Feat forms ignore immutable

### DIFF
--- a/lib/modules/forms/Field.js
+++ b/lib/modules/forms/Field.js
@@ -1,0 +1,17 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createField = require('redux-form/lib/createField');
+
+var _createField2 = _interopRequireDefault(_createField);
+
+var _plainStructure = require('./plainStructure');
+
+var _plainStructure2 = _interopRequireDefault(_plainStructure);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = (0, _createField2.default)(_plainStructure2.default);

--- a/lib/modules/forms/FieldArray.js
+++ b/lib/modules/forms/FieldArray.js
@@ -1,0 +1,17 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createFieldArray = require('redux-form/lib/createFieldArray');
+
+var _createFieldArray2 = _interopRequireDefault(_createFieldArray);
+
+var _plainStructure = require('./plainStructure');
+
+var _plainStructure2 = _interopRequireDefault(_plainStructure);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = (0, _createFieldArray2.default)(_plainStructure2.default);

--- a/lib/modules/forms/decorators/withForm.js
+++ b/lib/modules/forms/decorators/withForm.js
@@ -4,9 +4,13 @@ Object.defineProperty(exports, "__esModule", {
 	value: true
 });
 
-var _extends2 = require('babel-runtime/helpers/extends');
+var _promise = require('babel-runtime/core-js/promise');
 
-var _extends3 = _interopRequireDefault(_extends2);
+var _promise2 = _interopRequireDefault(_promise);
+
+var _extends3 = require('babel-runtime/helpers/extends');
+
+var _extends4 = _interopRequireDefault(_extends3);
 
 var _defineProperty2 = require('babel-runtime/helpers/defineProperty');
 
@@ -19,6 +23,22 @@ var _keys2 = _interopRequireDefault(_keys);
 var _toConsumableArray2 = require('babel-runtime/helpers/toConsumableArray');
 
 var _toConsumableArray3 = _interopRequireDefault(_toConsumableArray2);
+
+var _startsWith2 = require('lodash/startsWith');
+
+var _startsWith3 = _interopRequireDefault(_startsWith2);
+
+var _reduceRight2 = require('lodash/reduceRight');
+
+var _reduceRight3 = _interopRequireDefault(_reduceRight2);
+
+var _size2 = require('lodash/size');
+
+var _size3 = _interopRequireDefault(_size2);
+
+var _debounce2 = require('lodash/debounce');
+
+var _debounce3 = _interopRequireDefault(_debounce2);
 
 var _mapValues2 = require('lodash/mapValues');
 
@@ -58,6 +78,14 @@ var _dotObject2 = _interopRequireDefault(_dotObject);
 
 var _reduxForm = require('redux-form');
 
+var _createReduxForm = require('redux-form/lib/createReduxForm');
+
+var _createReduxForm2 = _interopRequireDefault(_createReduxForm);
+
+var _plainStructure = require('../plainStructure');
+
+var _plainStructure2 = _interopRequireDefault(_plainStructure);
+
 var _recompose = require('recompose');
 
 var _omitProps = require('../../../utils/omitProps');
@@ -65,6 +93,10 @@ var _omitProps = require('../../../utils/omitProps');
 var _omitProps2 = _interopRequireDefault(_omitProps);
 
 var _reactRedux = require('react-redux');
+
+var _immutable = require('immutable');
+
+var _immutable2 = _interopRequireDefault(_immutable);
 
 var _doOnPropsChange = require('../../../utils/doOnPropsChange');
 
@@ -88,8 +120,14 @@ var _normalizeValuesToValidate2 = _interopRequireDefault(_normalizeValuesToValid
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+var reduxForm = (0, _createReduxForm2.default)(_plainStructure2.default);
+
 var deepMap = function deepMap(obj, iterator, context) {
 	return (0, _transform3.default)(obj, function (result, val, key) {
+		if (_immutable2.default.Iterable.isIterable(val)) {
+			result[key] = val;
+			return;
+		}
 		result[key] = (0, _isObject3.default)(val) ? deepMap(val, iterator, context) : iterator.call(context, val, key, obj);
 	});
 };
@@ -114,87 +152,148 @@ var combineWithFieldsSchemas = function combineWithFieldsSchemas(mainSchema, fie
 	};
 };
 
+var debouncedValidation = (0, _debounce3.default)(function (_ref, cb) {
+	var values = _ref.values,
+	    props = _ref.props,
+	    schema = _ref.schema,
+	    errorMessagesPrefix = _ref.errorMessagesPrefix,
+	    errorMessages = _ref.errorMessages,
+	    userValidate = _ref.userValidate,
+	    notRequiredPaths = _ref.notRequiredPaths,
+	    requiredPaths = _ref.requiredPaths,
+	    fieldsSchemas = _ref.fieldsSchemas;
+	var registeredFields = props.registeredFields;
+
+	if (!registeredFields) {
+		// bail early if there are no fields to validate
+		return {};
+	}
+	var propsSchema = props.schema,
+	    propsErrorMessagesPrefix = props.errorMessagesPrefix,
+	    propsErrorMessages = props.errorMessages,
+	    propsUserValidate = props.userValidate;
+
+	var finalUserValidate = propsUserValidate || userValidate;
+
+	var finalErrorMessagesPrefix = propsErrorMessagesPrefix || errorMessagesPrefix;
+	var finalErrorMessages = propsErrorMessages || errorMessages;
+	if (finalErrorMessagesPrefix) {
+		finalErrorMessages = _dotObject2.default.pick(finalErrorMessagesPrefix, _dotObject2.default.object((0, _extends4.default)({}, finalErrorMessages)));
+	}
+	var finalSchema = propsSchema || schema;
+	finalSchema = combineWithFieldsSchemas(finalSchema, fieldsSchemas);
+	var normalizedValues = (0, _normalizeEmptyValues2.default)(values, finalSchema);
+	normalizedValues = (0, _normalizeValuesToValidate2.default)(normalizedValues, finalSchema, registeredFields);
+
+	var validateJsonSchemaErrors = wrapAsErrors((0, _validateByJsonSchema2.default)(normalizedValues, finalSchema, finalErrorMessages, requiredPaths, notRequiredPaths));
+
+	var userValidateErrors = {};
+	if (finalUserValidate) {
+		var userValidateErrorsUnwrapped = finalUserValidate(values, props);
+		var userValidateErrorsUnwrappedDot = _dotObject2.default.dot(userValidateErrorsUnwrapped);
+		var userValidateErrorsUnwrappedDotTranslated = (0, _mapValues3.default)(userValidateErrorsUnwrappedDot, function (errorName, propertyPath) {
+			return _dotObject2.default.pick(propertyPath + '.' + errorName, errorMessages) || '' + errorName;
+		});
+		var userValidateErrorsUnwrappedTranslated = _dotObject2.default.object(userValidateErrorsUnwrappedDotTranslated);
+		userValidateErrors = wrapAsErrors(userValidateErrorsUnwrappedTranslated);
+	}
+
+	var finalUserValidateErrors = _dotObject2.default.object((0, _reduce3.default)(_dotObject2.default.dot(userValidateErrors), function (result, value, key) {
+		var path = key + '.' + value;
+		result[key] = _dotObject2.default.pick(path, finalErrorMessages) || value; // eslint-disable-line no-param-reassign
+		return result;
+	}, {}));
+
+	cb((0, _mergeWithArrays2.default)({}, validateJsonSchemaErrors, finalUserValidateErrors));
+}, 500);
+
 var withForm = function withForm() {
 	var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
 	return (0, _recompose.compose)((0, _recompose.withProps)(function (props) {
 		return (0, _isFunction3.default)(options) ? options(props) : options;
-	}), (0, _recompose.withProps)(function (_ref) {
-		var initialValues = _ref.initialValues;
+	}), (0, _recompose.withProps)(function (_ref2) {
+		var initialValues = _ref2.initialValues;
 
 		return {
 			initialValues: deepMap(initialValues, function (v) {
 				return v === null ? undefined : v;
 			})
 		};
-	}), (0, _reactRedux.connect)(function (state, _ref2) {
-		var form = _ref2.form;
+	}), (0, _reactRedux.connect)(function (state, _ref3) {
+		var form = _ref3.form;
 		return { fieldsSchemas: (0, _get3.default)(state, ['formFieldsSchemas', form]) };
 	}), (0, _recompose.withHandlers)({
-		setExternalErrors: function setExternalErrors(_ref3) {
-			var dispatch = _ref3.dispatch;
+		setExternalErrors: function setExternalErrors(_ref4) {
+			var dispatch = _ref4.dispatch;
 			return function (targetForm, errors) {
 				dispatch((0, _reduxForm.stopSubmit)(targetForm, errors));
 			};
 		}
 	}), (0, _recompose.withHandlers)({
-		validate: function validate(_ref4) {
-			var schema = _ref4.schema,
-			    errorMessagesPrefix = _ref4.errorMessagesPrefix,
-			    errorMessages = _ref4.errorMessages,
-			    userValidate = _ref4.validate,
-			    notRequiredPaths = _ref4.notRequiredPaths,
-			    requiredPaths = _ref4.requiredPaths,
-			    fieldsSchemas = _ref4.fieldsSchemas;
-			return function (values, props) {
+		asyncValidate: function asyncValidate(_ref5) {
+			var schema = _ref5.schema,
+			    errorMessagesPrefix = _ref5.errorMessagesPrefix,
+			    errorMessages = _ref5.errorMessages,
+			    userValidate = _ref5.validate,
+			    notRequiredPaths = _ref5.notRequiredPaths,
+			    requiredPaths = _ref5.requiredPaths,
+			    fieldsSchemas = _ref5.fieldsSchemas;
+			return function (values, _, props) {
 				var registeredFields = props.registeredFields;
 
-				if (!registeredFields) {
-					// bail early if there are no fields to validate
-					return {};
-				}
-				var propsSchema = props.schema,
-				    propsErrorMessagesPrefix = props.errorMessagesPrefix,
-				    propsErrorMessages = props.errorMessages,
-				    propsUserValidate = props.userValidate;
+				var resolve = void 0;
+				var reject = void 0;
 
-				var finalUserValidate = propsUserValidate || userValidate;
+				debouncedValidation({
+					values: values,
+					props: props,
+					schema: schema,
+					errorMessagesPrefix: errorMessagesPrefix,
+					errorMessages: errorMessages,
+					userValidate: userValidate,
+					notRequiredPaths: notRequiredPaths,
+					requiredPaths: requiredPaths,
+					fieldsSchemas: fieldsSchemas
+				}, function (errors) {
+					var tmp = (0, _reduceRight3.default)((0, _keys2.default)(registeredFields).sort(), function (acc, path) {
+						if ((0, _startsWith3.default)((0, _get3.default)(acc, 'prevPath'), path)) {
+							return (0, _extends4.default)({}, acc, {
+								prevPath: path
+							});
+						}
 
-				var finalErrorMessagesPrefix = propsErrorMessagesPrefix || errorMessagesPrefix;
-				var finalErrorMessages = propsErrorMessages || errorMessages;
-				if (finalErrorMessagesPrefix) {
-					finalErrorMessages = _dotObject2.default.pick(finalErrorMessagesPrefix, _dotObject2.default.object((0, _extends3.default)({}, finalErrorMessages)));
-				}
-				var finalSchema = propsSchema || schema;
-				finalSchema = combineWithFieldsSchemas(finalSchema, fieldsSchemas);
-				var normalizedValues = (0, _normalizeEmptyValues2.default)(values, finalSchema);
-				normalizedValues = (0, _normalizeValuesToValidate2.default)(normalizedValues, finalSchema, registeredFields);
+						var picked = _dotObject2.default.pick(path, errors);
+						if (!picked) {
+							return (0, _extends4.default)({}, acc, {
+								prevPath: path
+							});
+						}
 
-				var validateJsonSchemaErrors = wrapAsErrors((0, _validateByJsonSchema2.default)(normalizedValues, finalSchema, finalErrorMessages, requiredPaths, notRequiredPaths));
+						return {
+							result: (0, _extends4.default)({}, (0, _get3.default)(acc, 'result'), (0, _defineProperty3.default)({}, path, picked)),
+							prevPath: path
+						};
+					}, { result: {}, prevPath: '' });
 
-				var userValidateErrors = {};
-				if (finalUserValidate) {
-					var userValidateErrorsUnwrapped = finalUserValidate(values, props);
-					var userValidateErrorsUnwrappedDot = _dotObject2.default.dot(userValidateErrorsUnwrapped);
-					var userValidateErrorsUnwrappedDotTranslated = (0, _mapValues3.default)(userValidateErrorsUnwrappedDot, function (errorName, propertyPath) {
-						return _dotObject2.default.pick(propertyPath + '.' + errorName, errorMessages) || '' + errorName;
-					});
-					var userValidateErrorsUnwrappedTranslated = _dotObject2.default.object(userValidateErrorsUnwrappedDotTranslated);
-					userValidateErrors = wrapAsErrors(userValidateErrorsUnwrappedTranslated);
-				}
+					var finalErrors = _dotObject2.default.object((0, _get3.default)(tmp, 'result'));
 
-				var finalUserValidateErrors = _dotObject2.default.object((0, _reduce3.default)(_dotObject2.default.dot(userValidateErrors), function (result, value, key) {
-					var path = key + '.' + value;
-					result[key] = _dotObject2.default.pick(path, finalErrorMessages) || value; // eslint-disable-line no-param-reassign
-					return result;
-				}, {}));
+					if ((0, _size3.default)(finalErrors)) {
+						reject(finalErrors);
+					} else {
+						resolve();
+					}
+				});
 
-				return (0, _mergeWithArrays2.default)({}, validateJsonSchemaErrors, finalUserValidateErrors);
+				return new _promise2.default(function (res, rej) {
+					resolve = res;
+					reject = rej;
+				});
 			};
 		},
-		checkErrors: function checkErrors(_ref5) {
-			var setExternalErrors = _ref5.setExternalErrors,
-			    formName = _ref5.form;
+		checkErrors: function checkErrors(_ref6) {
+			var setExternalErrors = _ref6.setExternalErrors,
+			    formName = _ref6.form;
 			return function (currentErrors, nextErrors, nextSubmitFailed) {
 				if (!(0, _isEmpty3.default)(nextErrors) && !nextSubmitFailed && nextErrors !== currentErrors) {
 					setExternalErrors(formName, nextErrors);
@@ -218,28 +317,38 @@ var withForm = function withForm() {
 
 			checkErrors(currentErrors, nextErrors, nextSubmitFailed);
 		}
-	}), (0, _omitProps2.default)(['errorMessagesPrefix', 'errorMessages', 'userValidate', 'checkErrors']), (0, _reduxForm.reduxForm)({
-		shouldValidate: function shouldValidate(_ref6) {
-			var values = _ref6.values,
-			    nextProps = _ref6.nextProps,
-			    props = _ref6.props,
-			    initialRender = _ref6.initialRender,
-			    lastFieldValidatorKeys = _ref6.lastFieldValidatorKeys,
-			    fieldValidatorKeys = _ref6.fieldValidatorKeys,
-			    structure = _ref6.structure;
+	}), (0, _recompose.withProps)(function (_ref7) {
+		var registeredFields = _ref7.registeredFields;
 
-			// debugger;
-			if (initialRender) {
-				return true;
-			}
-			var shouldValidate = !structure.deepEqual(values, nextProps && nextProps.values) || !structure.deepEqual(props.registeredFields, nextProps && nextProps.registeredFields) || !structure.deepEqual(lastFieldValidatorKeys, fieldValidatorKeys);
-			// console.log('SHOULD VALIDATE', shouldValidate);
-			return shouldValidate;
-		}
-	}), (0, _doOnPropsChange2.default)(['isBusy'], function (_ref7) {
-		var dispatch = _ref7.dispatch,
-		    form = _ref7.form,
-		    isBusy = _ref7.isBusy;
+		return {
+			asyncChangeFields: registeredFields
+		};
+	}), (0, _omitProps2.default)(['errorMessagesPrefix', 'errorMessages', 'userValidate', 'checkErrors']), reduxForm({
+		// shouldValidate: ({
+		// 	values,
+		// 	nextProps,
+		// 	props,
+		// 	initialRender,
+		// 	lastFieldValidatorKeys,
+		// 	fieldValidatorKeys,
+		// 	structure
+		// }) => {
+		// 	// debugger;
+		// 	if (initialRender) {
+		// 		return true
+		// 	}
+		// 	const shouldValidate = (
+		// 		!structure.deepEqual(values, nextProps && nextProps.values) ||
+		// 		!structure.deepEqual(props.registeredFields, nextProps && nextProps.registeredFields) ||
+		// 		!structure.deepEqual(lastFieldValidatorKeys, fieldValidatorKeys)
+		// 	);
+		// 	// console.log('SHOULD VALIDATE', shouldValidate);
+		// 	return shouldValidate;
+		// },
+	}), (0, _doOnPropsChange2.default)(['isBusy'], function (_ref8) {
+		var dispatch = _ref8.dispatch,
+		    form = _ref8.form,
+		    isBusy = _ref8.isBusy;
 
 		if (isBusy) {
 			dispatch((0, _reduxForm.startSubmit)(form));

--- a/lib/modules/forms/index.js
+++ b/lib/modules/forms/index.js
@@ -4,7 +4,13 @@ Object.defineProperty(exports, "__esModule", {
 	value: true
 });
 
-var _reduxForm = require('redux-form');
+var _createReducer = require('redux-form/lib/createReducer');
+
+var _createReducer2 = _interopRequireDefault(_createReducer);
+
+var _plainStructure = require('./plainStructure');
+
+var _plainStructure2 = _interopRequireDefault(_plainStructure);
 
 var _reducer = require('./reducer');
 
@@ -14,7 +20,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 exports.default = {
 	reducers: {
-		form: _reduxForm.reducer,
+		form: (0, _createReducer2.default)(_plainStructure2.default),
 		formFieldsSchemas: _reducer2.default
 	}
 };

--- a/lib/modules/forms/isDirty.js
+++ b/lib/modules/forms/isDirty.js
@@ -1,0 +1,17 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _isDirty = require('redux-form/lib/selectors/isDirty');
+
+var _isDirty2 = _interopRequireDefault(_isDirty);
+
+var _plainStructure = require('./plainStructure');
+
+var _plainStructure2 = _interopRequireDefault(_plainStructure);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = (0, _isDirty2.default)(_plainStructure2.default);

--- a/lib/modules/forms/isPristine.js
+++ b/lib/modules/forms/isPristine.js
@@ -1,0 +1,17 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _isPristine = require('redux-form/lib/selectors/isPristine');
+
+var _isPristine2 = _interopRequireDefault(_isPristine);
+
+var _plainStructure = require('./plainStructure');
+
+var _plainStructure2 = _interopRequireDefault(_plainStructure);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = (0, _isPristine2.default)(_plainStructure2.default);

--- a/lib/modules/forms/normalizeEmptyValues.js
+++ b/lib/modules/forms/normalizeEmptyValues.js
@@ -24,6 +24,10 @@ var _get2 = require('lodash/get');
 
 var _get3 = _interopRequireDefault(_get2);
 
+var _immutable = require('immutable');
+
+var _immutable2 = _interopRequireDefault(_immutable);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 /**
@@ -37,6 +41,10 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  * @return {{}}
  */
 var normalizeEmptyValues = function normalizeEmptyValues(data, schema) {
+	if (_immutable2.default.Iterable.isIterable(data)) {
+		return data;
+	};
+
 	return (0, _reduce3.default)(data, function (acc, propertyValue, propertyName) {
 		var propertySchema = (0, _get3.default)(schema, ['properties', propertyName]);
 		var type = (0, _get3.default)(propertySchema, 'type');

--- a/lib/modules/forms/normalizeValuesToValidate.js
+++ b/lib/modules/forms/normalizeValuesToValidate.js
@@ -12,9 +12,13 @@ var _stringify = require('babel-runtime/core-js/json/stringify');
 
 var _stringify2 = _interopRequireDefault(_stringify);
 
-var _cloneDeep2 = require('lodash/cloneDeep');
+var _cloneDeepWith2 = require('lodash/cloneDeepWith');
 
-var _cloneDeep3 = _interopRequireDefault(_cloneDeep2);
+var _cloneDeepWith3 = _interopRequireDefault(_cloneDeepWith2);
+
+var _clone2 = require('lodash/clone');
+
+var _clone3 = _interopRequireDefault(_clone2);
 
 var _set2 = require('lodash/set');
 
@@ -23,6 +27,10 @@ var _set3 = _interopRequireDefault(_set2);
 var _get2 = require('lodash/get');
 
 var _get3 = _interopRequireDefault(_get2);
+
+var _immutable = require('immutable');
+
+var _immutable2 = _interopRequireDefault(_immutable);
 
 var _dotObject = require('dot-object');
 
@@ -38,9 +46,20 @@ var normalizeValuesToValidate = function normalizeValuesToValidate(data, schema,
 	});
 	(0, _keys2.default)(registeredFields).forEach(function (fieldPath) {
 		var fieldType = registeredFields[fieldPath].type;
-		var fieldValue = (0, _cloneDeep3.default)((0, _get3.default)(data, fieldPath)); // dot-object mutates arguments 🙄
+		var originalFieldValue = (0, _get3.default)(data, fieldPath);
+		var fieldValue = void 0;
+
+		fieldValue = (0, _cloneDeepWith3.default)(originalFieldValue, function (value) {
+			if (_immutable2.default.Iterable.isIterable(value)) {
+				return {};
+			}
+
+			return (0, _clone3.default)(value);
+		}); // dot-object mutates arguments 🙄
+
 		(0, _set3.default)(dataToValidate, fieldPath, fieldType === 'FieldArray' ? fieldValue || [] : fieldValue);
 	});
+
 	return dataToValidate;
 };
 

--- a/lib/modules/forms/plainStructure.js
+++ b/lib/modules/forms/plainStructure.js
@@ -1,0 +1,51 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});
+
+var _extends2 = require('babel-runtime/helpers/extends');
+
+var _extends3 = _interopRequireDefault(_extends2);
+
+var _isEqualWith2 = require('lodash/isEqualWith');
+
+var _isEqualWith3 = _interopRequireDefault(_isEqualWith2);
+
+var _plain = require('redux-form/lib/structure/plain');
+
+var _plain2 = _interopRequireDefault(_plain);
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _immutable = require('immutable');
+
+var _immutable2 = _interopRequireDefault(_immutable);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var structure = (0, _extends3.default)({}, _plain2.default, {
+	deepEqual: function deepEqual(object, objectOther) {
+		return (0, _isEqualWith3.default)(object, objectOther, function (obj, other) {
+			if (obj === other) return true;
+
+			if (_immutable2.default.Iterable.isIterable(obj) || _immutable2.default.Iterable.isIterable(other)) {
+				return obj === other;
+			}
+
+			if (!obj && !other) {
+				var objIsEmpty = obj === null || obj === undefined || obj === '';
+				var otherIsEmpty = other === null || other === undefined || other === '';
+				return objIsEmpty === otherIsEmpty;
+			}
+
+			if (obj && other && obj._error !== other._error) return false;
+			if (obj && other && obj._warning !== other._warning) return false;
+			if (_react2.default.isValidElement(obj) || _react2.default.isValidElement(other)) return false;
+		});
+	}
+});
+
+exports.default = structure;

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "peerDependencies": {
     "classnames": "^2.2.5",
+    "immutable": "^3.8.2",
     "react": "^15.6.0",
     "react-dom": "^15.6.0",
     "react-redux": "^5.0.5",

--- a/src/modules/forms/Field.js
+++ b/src/modules/forms/Field.js
@@ -1,0 +1,4 @@
+import createField from 'redux-form/lib/createField'
+import plain from './plainStructure'
+
+export default createField(plain)

--- a/src/modules/forms/FieldArray.js
+++ b/src/modules/forms/FieldArray.js
@@ -1,0 +1,4 @@
+import createFieldArray from 'redux-form/lib/createFieldArray'
+import plain from './plainStructure'
+
+export default createFieldArray(plain)

--- a/src/modules/forms/index.js
+++ b/src/modules/forms/index.js
@@ -1,9 +1,10 @@
-import { reducer as formReducer } from 'redux-form';
+import createReducer from 'redux-form/lib/createReducer';
+import plain from './plainStructure';
 import formFieldsSchemas from './reducer';
 
 export default {
 	reducers: {
-		form: formReducer,
+		form: createReducer(plain),
 		formFieldsSchemas,
 	}
 };

--- a/src/modules/forms/isDirty.js
+++ b/src/modules/forms/isDirty.js
@@ -1,0 +1,4 @@
+import createIsDirty from 'redux-form/lib/selectors/isDirty'
+import plain from './plainStructure'
+
+export default createIsDirty(plain)

--- a/src/modules/forms/isPristine.js
+++ b/src/modules/forms/isPristine.js
@@ -1,0 +1,4 @@
+import createIsPristine from 'redux-form/lib/selectors/isPristine'
+import plain from './plainStructure'
+
+export default createIsPristine(plain)

--- a/src/modules/forms/normalizeEmptyValues.js
+++ b/src/modules/forms/normalizeEmptyValues.js
@@ -1,4 +1,5 @@
 import { get as g, reduce, isString } from 'lodash';
+import Immutable from 'immutable';
 
 /**
  * Omits empty string properties ("")
@@ -11,6 +12,10 @@ import { get as g, reduce, isString } from 'lodash';
  * @return {{}}
  */
 const normalizeEmptyValues = (data, schema) => {
+	if (Immutable.Iterable.isIterable(data)) {
+		return data;
+	};
+
 	return reduce(data, (acc, propertyValue, propertyName) => {
 		const propertySchema = g(schema, ['properties', propertyName]);
 		const type = g(propertySchema, 'type');

--- a/src/modules/forms/normalizeValuesToValidate.js
+++ b/src/modules/forms/normalizeValuesToValidate.js
@@ -1,4 +1,5 @@
-import { get as g, set, isPlainObject, reduce, mapValues, cloneDeep } from 'lodash';
+import { get as g, set, isPlainObject, reduce, mapValues, clone, cloneDeepWith } from 'lodash';
+import Immutable from 'immutable';
 import dot from 'dot-object';
 
 const normalizeValuesToValidate = (data, schema, registeredFields) => {
@@ -12,10 +13,21 @@ const normalizeValuesToValidate = (data, schema, registeredFields) => {
 	Object.keys(registeredFields).forEach(
 		(fieldPath) => {
 			const fieldType = registeredFields[fieldPath].type;
-			const fieldValue = cloneDeep(g(data, fieldPath)); // dot-object mutates arguments 🙄
+			const originalFieldValue = g(data, fieldPath);
+			let fieldValue;
+
+			fieldValue = cloneDeepWith(originalFieldValue, (value) => {
+				if (Immutable.Iterable.isIterable(value)) {
+					return {};
+				}
+
+				return clone(value);
+			}); // dot-object mutates arguments 🙄
+
 			set(dataToValidate, fieldPath, fieldType === 'FieldArray' ? (fieldValue || []) : fieldValue);
 		},
 	);
+
 	return dataToValidate;
 };
 

--- a/src/modules/forms/plainStructure.js
+++ b/src/modules/forms/plainStructure.js
@@ -1,0 +1,33 @@
+import reduxFormStructure from 'redux-form/lib/structure/plain';
+import React from 'react';
+import { isEqualWith } from 'lodash';
+import Immutable from 'immutable';
+
+const structure = {
+	...reduxFormStructure,
+	deepEqual: (object, objectOther) => {
+		return isEqualWith(object, objectOther, (obj, other) => {
+			if (obj === other) return true
+
+			if (
+				Immutable.Iterable.isIterable(obj) ||
+				Immutable.Iterable.isIterable(other)
+			) {
+				return obj === other;
+			}
+
+
+			if (!obj && !other) {
+			  const objIsEmpty = obj === null || obj === undefined || obj === ''
+			  const otherIsEmpty = other === null || other === undefined || other === ''
+			  return objIsEmpty === otherIsEmpty
+			}
+
+			if (obj && other && obj._error !== other._error) return false
+			if (obj && other && obj._warning !== other._warning) return false
+			if (React.isValidElement(obj) || React.isValidElement(other)) return false
+		});
+	},
+};
+
+export default structure;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1310,6 +1310,10 @@ iconv-lite@~0.4.13:
   version "0.4.17"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.17.tgz#4fdaa3b38acbc2c031b045d0edcdfe1ecab18c8d"
 
+immutable@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"


### PR DESCRIPTION
updated forms module.
- Added custom Field, FieldArray and reduxForm components. These perform deep equal of values every time props change. This deep equal function thowed warning when dealing with immutable structures. New custom ones uses extended deep equal.

- Also added custom isPristine and isDirty selectors for same reasons

- Updated normalizeEmptyValues and normalizeValuesToValidate so they can handle immutable data structures.

- Updated withForm. Switch from synchronous validation to asynchronous validation, debouncing validation 500 ms.